### PR TITLE
feat: add rich table output for capital repayment mortgage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ instructions on how to test the package, visit [TESTING.md](./TESTING.md)
 
 ## add/update a dependency
 
-Depedencies are managed using `uv` to add a dependency run the following command:
+Dependencies are managed using `uv` to add a dependency run the following command:
 
 ```bash
 uv add example-package # dependency

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
 keywords = ["mortgage"]
 dependencies = [
     "python-dateutil>=2.9.0.post0",
+    "rich>=13.9.4",
 ]
 requires-python = ">=3.9"
 

--- a/src/mortgagepy/mortgage.py
+++ b/src/mortgagepy/mortgage.py
@@ -2,6 +2,10 @@
 
 from functools import cache
 
+from rich import box
+from rich.console import Console
+from rich.table import Table
+
 from .calculator import (
     capital_overpayment,
     ltv,
@@ -137,18 +141,22 @@ class CapitalRepaymentMortgage(MortgageBase):
             dict: dictionary of mortgage summary.
         """
         summary_dict = {
-            "property value (£)": self.property_value,
-            "mortgage (£)": self.mortgage,
-            "loan to value (%)": self.ltv(),
-            "monthly repayment (£)": self.monthly_repayment(),
+            "property value": f"£{self.property_value:,}",
+            "mortgage": f"£{self.mortgage:,}",
+            "loan to value": f"{self.ltv()}%",
+            "monthly repayment": f"£{self.monthly_repayment():,}",
             "term (months)": int(self.term_months),
-            "interest rate (%)": self.interest_rate,
-            "interest paid (£)": self.interest_paid(),
-            "total cost (£)": self.mortgage_total_cost(),
+            "interest rate": f"{self.interest_rate}%",
+            "interest paid": f"£{self.interest_paid()}",
+            "total cost": f"£{self.mortgage_total_cost():,}",
         }
         if printed:
-            for key, value in summary_dict.items():
-                print(f"{key:<25}: {value}")
+            title = "Capital Repayment Mortgage Summary"
+            table = Table(title=title, header_style="bold", box=box.HEAVY)
+            for key in summary_dict:
+                table.add_column(key.title(), vertical="top")
+            table.add_row(*map(str, summary_dict.values()))
+            Console().print(table)
         else:
             return summary_dict
 

--- a/uv.lock
+++ b/uv.lock
@@ -143,11 +143,33 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528 },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979 },
+]
+
+[[package]]
 name = "mortgagepy"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "python-dateutil" },
+    { name = "rich" },
 ]
 
 [package.dev-dependencies]
@@ -159,7 +181,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "python-dateutil", specifier = ">=2.9.0.post0" }]
+requires-dist = [
+    { name = "python-dateutil", specifier = ">=2.9.0.post0" },
+    { name = "rich", specifier = ">=13.9.4" },
+]
 
 [package.metadata.requires-dev]
 dev = [
@@ -194,6 +219,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293 },
 ]
 
 [[package]]
@@ -249,6 +283,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892 },
+]
+
+[[package]]
+name = "rich"
+version = "13.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098", size = 223149 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl", hash = "sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90", size = 242424 },
 ]
 
 [[package]]


### PR DESCRIPTION
Incoprtation of `rich` summary tables and text formatting into package. Could be extended to render and display exceptions or add a package CLI.

1. Textualize rich added to uv dependencies
2. CapitalRepaymentMortgage class summarise method prints rich table summary